### PR TITLE
Fix Hosts Sniffing with Dummy Connection Pool

### DIFF
--- a/elasticsearch/connection_pool.py
+++ b/elasticsearch/connection_pool.py
@@ -236,7 +236,9 @@ class DummyConnectionPool(ConnectionPool):
         # we need connection opts for sniffing logic
         self.connection_opts = connections
         self.connection = connections[0][0]
-        self.connections = (self.connection, )
+
+        # for concatenation with other connection lists
+        self.connections = [self.connection, ]
 
     def get_connection(self):
         return self.connection


### PR DESCRIPTION
Assume a functional Elasticsearch cluster with more than one host. When a single host is configured during initialization of the python Elasticsearch client an error condition will be created during host sniffing.

When only one host is configured Transport sets seed_connections with a **tuple** from DummyConnectionPool. Calling Transport's sniff_hosts method will then find all of the hosts and reconfigure itself with a standard ConnectionPool which returns a **list** of connections.

Transport's sniff_hosts method concatenates both seed_connections and Transport's connections but because their types now differ (tuple and list respectively) the operation fails on the next call to sniff_hosts.

Demonstration:

    # Have an ElasticSearch cluster setup with *more than one* host 
    # (i.e. localhost, otherhost).

    # Create a python ES client with *only one* of the hosts

    >>> es = Elasticsearch(hosts=[{'host': 'localhost', 'port': 9200}])

    # Tuple set for seed connections

    >>> es.transport.seed_connections
    (<Urllib3HttpConnection: http://localhost:9200>,)

    # Tuple set for pool connections (so far so good)

    >>> es.transport.connection_pool.connections
    (<Urllib3HttpConnection: http://localhost:9200>,)

    # Sniffing hosts will now switch the connection pool from DummyConnectionPool 
    # to ConnectionPool (because more than one host was found)

    >>> es.transport.sniff_hosts()

    # Now a *list* is set for pool connections (we now have a problem)

    >>> es.transport.connection_pool.connections
    [<Urllib3HttpConnection: http://localhost:9200>, <Urllib3HttpConnection: http://otherhost:9200>]

    # Sniffing again causes an error because now we're trying to concatenate the 
    # list from transport.connection_pool.connections with the tuple from 
    # transport.seed_connections

    >>> es.transport.sniff_hosts()

    Traceback (most recent call last):
      File "...\elasticsearch\transport.py", line 198, in sniff_hosts
        for c in self.connection_pool.connections + self.seed_connections:
    TypeError: can only concatenate list (not "tuple") to list


There are multiple solutions:
  1. Change the DummyConnectionPool connections attribute to a list by default (instead of a tuple)
  2. Ensure that seed_connections is always set to a list during Transport initialization
  3. Modify sniff_hosts method to always cast seed_connections to a list before looping

The first option seems to be the most straight-forward in the long run and is included in this PR.

Cheers,
Leigh

*P.S. I have signed the contributor agreement as of 30-Jan-2015*
