### PR TITLE
Only update scroll id if all shards were successful for scanning

### DIFF
--- a/elasticsearch/helpers/__init__.py
+++ b/elasticsearch/helpers/__init__.py
@@ -34,7 +34,7 @@ def expand_action(data):
 
 
 def streaming_bulk(client, actions, chunk_size=500, raise_on_error=False,
-        expand_action_callback=expand_action, raise_on_exception=True, 
+        expand_action_callback=expand_action, raise_on_exception=True,
         **kwargs):
     """
     Streaming bulk consumes actions from the iterable passed in and yields
@@ -232,7 +232,8 @@ def scan(client, query=None, scroll='5m', preserve_order=False, **kwargs):
             break
         for hit in resp['hits']['hits']:
             yield hit
-        scroll_id = resp.get('_scroll_id')
+        if resp["_shards"]["successful"] == resp["_shards"]["total"]:
+            scroll_id = resp.get('_scroll_id')
         if scroll_id is None:
             break
 


### PR DESCRIPTION
Sometimes a shard will fail on a scan. If it does, it won't be aware of the new scan id, so the old one should still be used until successful.

If you have many shards, decent load, and scan over a large enough set, you'll definitely run into this problem.