### PR TITLE
self.connections needs to be an array not a tuple

### DIFF
--- a/elasticsearch/connection_pool.py
+++ b/elasticsearch/connection_pool.py
@@ -236,7 +236,7 @@ class DummyConnectionPool(ConnectionPool):
         # we need connection opts for sniffing logic
         self.connection_opts = connections
         self.connection = connections[0][0]
-        self.connections = (self.connection, )
+        self.connections = [self.connection]
 
     def get_connection(self):
         return self.connection


### PR DESCRIPTION
When connecting to a single host in a cluster with sniffing enabled, it tried to add all the cluster members to the DummyConnectionPool. This then fails with:

TypeError: can only concatenate list (not "tuple") to list

Changing the connections to an array in the constructor gets it working...