### PR TITLE
Added an option to suppress ssl check warning this warning appears in re...

### DIFF
--- a/elasticsearch/connection/http_requests.py
+++ b/elasticsearch/connection/http_requests.py
@@ -25,7 +25,7 @@ class RequestsHttpConnection(Connection):
     """
     def __init__(self, host='localhost', port=9200, http_auth=None,
         use_ssl=False, verify_certs=False, ca_certs=None, client_cert=None,
-        **kwargs):
+        show_ssl_warnings=True, **kwargs):
         if not REQUESTS_AVAILABLE:
             raise ImproperlyConfigured("Please install requests to use RequestsHttpConnection.")
 
@@ -48,8 +48,9 @@ class RequestsHttpConnection(Connection):
             self.session.verify = ca_certs
 
         if use_ssl and not verify_certs:
-            warnings.warn(
-                'Connecting to %s using SSL with verify_certs=False is insecure.' % self.base_url)
+            if show_ssl_warnings:
+                warnings.warn(
+                    'Connecting to %s using SSL with verify_certs=False is insecure.' % self.base_url)
 
     def perform_request(self, method, url, params=None, body=None, timeout=None, ignore=()):
         url = self.base_url + url

--- a/elasticsearch/connection/http_urllib3.py
+++ b/elasticsearch/connection/http_urllib3.py
@@ -25,7 +25,7 @@ class Urllib3HttpConnection(Connection):
     """
     def __init__(self, host='localhost', port=9200, http_auth=None,
             use_ssl=False, verify_certs=False, ca_certs=None, client_cert=None,
-            maxsize=10, **kwargs):
+            maxsize=10, show_ssl_warnings=True, **kwargs):
 
         super(Urllib3HttpConnection, self).__init__(host=host, port=port, **kwargs)
         self.headers = {}
@@ -46,8 +46,9 @@ class Urllib3HttpConnection(Connection):
             elif ca_certs:
                 raise ImproperlyConfigured("You cannot pass CA certificates when verify SSL is off.")
             else:
-                warnings.warn(
-                    'Connecting to %s using SSL with verify_certs=False is insecure.' % host)
+                if show_ssl_warnings:
+                    warnings.warn(
+                        'Connecting to %s using SSL with verify_certs=False is insecure.' % host)
 
         self.pool = pool_class(host, port=port, timeout=self.timeout, maxsize=maxsize, **kw)
 


### PR DESCRIPTION
Added an option called *show_ssl_warnings=True/False* to suppress ssl check warning this warning appears in request client at 
*http_urllib3* and *http_requests* https://github.com/elasticsearch/elasticsearch-py/blob/master/elasticsearch/connection/http_urllib3.py#L49 https://github.com/elasticsearch/elasticsearch-py/blob/master/elasticsearch/connection/http_requests.py#L50

Now if we want to hide warnings like *Connecting to %s using SSL with verify_certs=False is insecure.* we can pass this keyword argument like
```python
Elasticsearch(hosts=HOSTS, show_ssl_warnings=False)
```